### PR TITLE
Fix block.json error

### DIFF
--- a/block.json
+++ b/block.json
@@ -58,7 +58,7 @@
 		"flipHorizontal": {
 			"type": "boolean"
 		},
-		"flipHVertical": {
+		"flipVertical": {
 			"type": "boolean"
 		},
 		"width": {


### PR DESCRIPTION
Fixes #4 

The `flipVertical` attribute had a typo, which is fixed in this PR. 